### PR TITLE
Added NotElementOf

### DIFF
--- a/src/main/java/com/discretion/AbstractMathObjectVisitor.java
+++ b/src/main/java/com/discretion/AbstractMathObjectVisitor.java
@@ -14,15 +14,15 @@ public class AbstractMathObjectVisitor implements MathObjectVisitor {
         handle(variable);
     }
 
-    public final void visit(ElementOf elem) {
-        handle(elem);
+	public final void visit(ElementOf elem) {
+		handle(elem);
 
-        parent = elem;
-        elem.getElement().accept(this);
+		parent = elem;
+		elem.getElement().accept(this);
 
-        parent = elem;
-        elem.getSet().accept(this);
-    }
+		parent = elem;
+		elem.getSet().accept(this);
+	}
 
     public final void visit(Equality equality) {
         handle(equality);

--- a/src/main/java/com/discretion/MathObject.java
+++ b/src/main/java/com/discretion/MathObject.java
@@ -1,5 +1,6 @@
 package com.discretion;
 
+import com.discretion.statement.Negation;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
@@ -11,6 +12,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         use = JsonTypeInfo.Id.MINIMAL_CLASS,
         include = JsonTypeInfo.As.PROPERTY,
         property = "type")
-public interface MathObject {
-    void accept(MathObjectVisitor visitor);
+public abstract class MathObject {
+    public abstract void accept(MathObjectVisitor visitor);
+
+	public MathObject negate() {
+		return new Negation(this);
+	}
+
+	public boolean isNegative() {
+		return false;
+	}
 }

--- a/src/main/java/com/discretion/MathObjectVisitor.java
+++ b/src/main/java/com/discretion/MathObjectVisitor.java
@@ -5,7 +5,7 @@ import com.discretion.statement.*;
 
 public interface MathObjectVisitor {
     void visit(Variable variable);
-    void visit(ElementOf elem);
+	void visit(ElementOf elem);
     void visit(Equality equality);
     void visit(SubsetOf subset);
     void visit(SetUnion union);

--- a/src/main/java/com/discretion/PrettyPrinter.java
+++ b/src/main/java/com/discretion/PrettyPrinter.java
@@ -38,7 +38,7 @@ public class PrettyPrinter implements MathObjectVisitor {
 
     public void visit(ElementOf elem) {
         elem.getElement().accept(this);
-        pretty += " ∈ ";
+        pretty += elem.isNegative() ? " ∉ " : " ∈ ";
         elem.getSet().accept(this);
     }
 
@@ -90,8 +90,8 @@ public class PrettyPrinter implements MathObjectVisitor {
     }
 
     public void visit(Negation negation) {
-        pretty += "¬";
-        parensIfNeeded(negation, negation.getTerm());
+		pretty += "¬";
+		parensIfNeeded(negation, negation.getTerm());
     }
 
 	public void visit(CartesianProduct product) {
@@ -126,7 +126,10 @@ public class PrettyPrinter implements MathObjectVisitor {
 
 		precedence.put(SetComplement.class, p++);
 
-		precedence.put(ElementOf.class, p++);
+		// Equal precedence for ElementOf and NotElementOf
+		precedence.put(ElementOf.class, p);
+		precedence.put(NotElementOf.class, p++);
+
 		precedence.put(SubsetOf.class, p++);
 		precedence.put(Negation.class, p++);
 		precedence.put(Variable.class, p);
@@ -153,4 +156,5 @@ public class PrettyPrinter implements MathObjectVisitor {
 	private String pretty;
 	private boolean useEnglish;
 	private HashMap<Class<?>, Integer> precedence;
+	private MathObject parent;
 }

--- a/src/main/java/com/discretion/expression/CartesianProduct.java
+++ b/src/main/java/com/discretion/expression/CartesianProduct.java
@@ -5,7 +5,7 @@ import com.discretion.MathObjectVisitor;
 
 import java.util.Arrays;
 
-public class CartesianProduct implements MathObject {
+public class CartesianProduct extends MathObject {
 
 	public void accept(MathObjectVisitor visitor) {
 		visitor.visit(this);

--- a/src/main/java/com/discretion/expression/SetComplement.java
+++ b/src/main/java/com/discretion/expression/SetComplement.java
@@ -4,7 +4,7 @@ import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 import com.discretion.statement.Variable;
 
-public class SetComplement implements MathObject {
+public class SetComplement extends MathObject {
 
     public boolean equals(Object other) {
         if (!(other instanceof SetComplement))

--- a/src/main/java/com/discretion/expression/SetDifference.java
+++ b/src/main/java/com/discretion/expression/SetDifference.java
@@ -4,7 +4,7 @@ import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 import com.discretion.statement.Variable;
 
-public class SetDifference implements MathObject {
+public class SetDifference extends MathObject {
 
     public boolean equals(Object other) {
         if (!(other instanceof SetDifference))

--- a/src/main/java/com/discretion/expression/SetIntersection.java
+++ b/src/main/java/com/discretion/expression/SetIntersection.java
@@ -3,7 +3,7 @@ package com.discretion.expression;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class SetIntersection implements MathObject {
+public class SetIntersection extends MathObject {
 
     public boolean equals(Object other) {
         if (!(other instanceof SetIntersection))

--- a/src/main/java/com/discretion/expression/SetUnion.java
+++ b/src/main/java/com/discretion/expression/SetUnion.java
@@ -4,7 +4,7 @@ import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 import com.discretion.statement.Variable;
 
-public class SetUnion implements MathObject {
+public class SetUnion extends MathObject {
 
     public boolean equals(Object other) {
         if (!(other instanceof SetUnion))

--- a/src/main/java/com/discretion/solver/inference/DeMorgansLaw.java
+++ b/src/main/java/com/discretion/solver/inference/DeMorgansLaw.java
@@ -38,8 +38,8 @@ public class DeMorgansLaw extends AbstractMathObjectVisitor implements Inference
 
         Statement notDisjunction = new Negation(
                 new Disjunction(
-                        negate(conjunction.getLeft()),
-                        negate(conjunction.getRight())
+                        conjunction.getLeft().negate(),
+                        conjunction.getRight().negate()
                 )
         );
         Statement replaced = (Statement)replacer.substitute(originalStatement, conjunction, notDisjunction);
@@ -53,8 +53,8 @@ public class DeMorgansLaw extends AbstractMathObjectVisitor implements Inference
 
         Statement notConjunction = new Negation(
                 new Conjunction(
-                        negate(disjunction.getLeft()),
-                        negate(disjunction.getRight())
+                        disjunction.getLeft().negate(),
+                        disjunction.getRight().negate()
                 )
         );
         Statement replaced = (Statement)replacer.substitute(originalStatement, disjunction, notConjunction);
@@ -65,24 +65,17 @@ public class DeMorgansLaw extends AbstractMathObjectVisitor implements Inference
     protected void handle(Negation negation) {
         if (negation.getTerm() instanceof Disjunction) {
             Disjunction disjunction = (Disjunction)negation.getTerm();
-            Conjunction conjunction = new Conjunction(negate(disjunction.getLeft()), negate(disjunction.getRight()));
+            Conjunction conjunction = new Conjunction(disjunction.getLeft().negate(), disjunction.getRight().negate());
             Statement replaced = (Statement)replacer.substitute(originalStatement, negation, conjunction);
             inferences.add(new ProofStatement(replaced, "by DeMorgan's Law"));
         }
 
         if (negation.getTerm() instanceof Conjunction) {
             Conjunction conjunction = (Conjunction)negation.getTerm();
-            Disjunction disjunction = new Disjunction(negate(conjunction.getLeft()), negate(conjunction.getRight()));
+            Disjunction disjunction = new Disjunction(conjunction.getLeft().negate(), conjunction.getRight().negate());
             Statement replaced = (Statement)replacer.substitute(originalStatement, negation, disjunction);
             inferences.add(new ProofStatement(replaced, "by DeMorgan's Law"));
         }
-    }
-
-    private MathObject negate(MathObject object) {
-        if (object instanceof Negation)
-            return ((Negation)object).getTerm();
-
-        return new Negation(object);
     }
 
     private Statement originalStatement;

--- a/src/main/java/com/discretion/solver/inference/DoubleNegative.java
+++ b/src/main/java/com/discretion/solver/inference/DoubleNegative.java
@@ -33,8 +33,8 @@ public class DoubleNegative extends AbstractMathObjectVisitor implements Inferen
     @Override
     protected void handle(Negation negation) {
 		// TODO make sure that a triple negative doesn't produce a duplicate inference
-		if (negation.getTerm() instanceof Negation) {
-			Statement term = (Statement) ((Negation)negation.getTerm()).getTerm();
+		if (negation.getTerm().isNegative()) {
+			Statement term = (Statement) negation.getTerm().negate();
 			Statement simplified = (Statement)replacer.substitute(originalStatement, negation, term);
 			inferences.add(new ProofStatement(simplified, "by double negative"));
 		}

--- a/src/main/java/com/discretion/solver/inference/SetComplementInference.java
+++ b/src/main/java/com/discretion/solver/inference/SetComplementInference.java
@@ -8,6 +8,7 @@ import com.discretion.solver.Replacer;
 import com.discretion.solver.environment.TruthEnvironment;
 import com.discretion.statement.ElementOf;
 import com.discretion.statement.Negation;
+import com.discretion.statement.NotElementOf;
 import com.discretion.statement.Statement;
 
 import java.util.LinkedList;
@@ -31,38 +32,28 @@ public class SetComplementInference extends AbstractMathObjectVisitor implements
     }
 
     @Override
-    protected void handle(Negation negation) {
-        MathObject negated = negation.getTerm();
-        if (negated instanceof ElementOf) {
-            ElementOf elementOf = (ElementOf)negated;
-            MathObject set = elementOf.getSet();
-            MathObject complemented = (set instanceof SetComplement) ?
-                    ((SetComplement)set).getSet()
-                    : new SetComplement(set);
-
-            ElementOf elementOfComplement = new ElementOf(elementOf.getElement(), complemented);
-            Statement replaced = (Statement)replacer.substitute(originalStatement, negation, elementOfComplement);
-
-            inferences.add(new ProofStatement(replaced, "by the definition of set complement"));
-        }
-    }
-
-    @Override
     protected void handle(ElementOf elementOf) {
-        if (parent instanceof Negation)
-            return;
+        if (elementOf.isNegative()) {
+			MathObject set = elementOf.getSet();
+			MathObject complemented = (set instanceof SetComplement) ?
+					((SetComplement)set).getSet()
+					: new SetComplement(set);
 
-        MathObject set = elementOf.getSet();
-        MathObject complemented = (set instanceof SetComplement) ?
-                ((SetComplement)set).getSet()
-                : new SetComplement(set);
+			ElementOf elementOfComplement = new ElementOf(elementOf.getElement(), complemented);
+			Statement replaced = (Statement)replacer.substitute(originalStatement, elementOf, elementOfComplement);
 
-        Negation negation = new Negation(
-            new ElementOf(elementOf.getElement(), complemented)
-        );
-        Statement replaced = (Statement)replacer.substitute(originalStatement, elementOf, negation);
+			inferences.add(new ProofStatement(replaced, "by the definition of set complement"));
+		} else {
+			MathObject set = elementOf.getSet();
+			MathObject complemented = (set instanceof SetComplement) ?
+					((SetComplement) set).getSet()
+					: new SetComplement(set);
 
-        inferences.add(new ProofStatement(replaced, "by the definition of set complement"));
+			NotElementOf notElementOf = new NotElementOf(elementOf.getElement(), complemented);
+			Statement replaced = (Statement) replacer.substitute(originalStatement, elementOf, notElementOf);
+
+			inferences.add(new ProofStatement(replaced, "by the definition of set complement"));
+		}
     }
 
     private Statement originalStatement;

--- a/src/main/java/com/discretion/statement/Conjunction.java
+++ b/src/main/java/com/discretion/statement/Conjunction.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class Conjunction implements Statement {
+public class Conjunction extends Statement {
 
     public boolean equals(Object other) {
         if (!(other instanceof Conjunction))

--- a/src/main/java/com/discretion/statement/Disjunction.java
+++ b/src/main/java/com/discretion/statement/Disjunction.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class Disjunction implements Statement {
+public class Disjunction extends Statement {
 
     public boolean equals(Object other) {
         if (!(other instanceof Disjunction))
@@ -36,6 +36,11 @@ public class Disjunction implements Statement {
         this.left = left;
         this.right = right;
     }
+
+	public Disjunction(String left, String right) {
+		this.left = new Variable(left);
+		this.right = new Variable(right);
+	}
 
     public Disjunction() {
     }

--- a/src/main/java/com/discretion/statement/ElementOf.java
+++ b/src/main/java/com/discretion/statement/ElementOf.java
@@ -3,13 +3,15 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class ElementOf implements Statement {
+public class ElementOf extends Statement {
 
     public boolean equals(Object other) {
         if (!(other instanceof ElementOf))
             return false;
         ElementOf otherElement = (ElementOf)other;
-        return element.equals(otherElement.element) && set.equals(otherElement.set);
+        return element.equals(otherElement.element)
+				&& set.equals(otherElement.set)
+				&& isNegative() == otherElement.isNegative();
     }
 
     public MathObject getElement() {
@@ -32,6 +34,11 @@ public class ElementOf implements Statement {
         visitor.visit(this);
     }
 
+	@Override
+	public MathObject negate() {
+		return new NotElementOf(element, set);
+	}
+
     public ElementOf(MathObject element, MathObject set) {
         this.element = element;
         this.set = set;
@@ -45,6 +52,6 @@ public class ElementOf implements Statement {
     public ElementOf() {
     }
 
-    private MathObject element;
-    private MathObject set;
+    protected MathObject element;
+    protected MathObject set;
 }

--- a/src/main/java/com/discretion/statement/Equality.java
+++ b/src/main/java/com/discretion/statement/Equality.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class Equality implements Statement {
+public class Equality extends Statement {
 
     public boolean equals(Object other) {
         if (!(other instanceof Equality))

--- a/src/main/java/com/discretion/statement/Negation.java
+++ b/src/main/java/com/discretion/statement/Negation.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class Negation implements Statement {
+public class Negation extends Statement {
 
     public boolean equals(Object other) {
         return other instanceof Negation
@@ -22,9 +22,23 @@ public class Negation implements Statement {
         visitor.visit(this);
     }
 
+	@Override
+	public MathObject negate() {
+		return term;
+	}
+
+	@Override
+	public boolean isNegative() {
+		return true;
+	}
+
     public Negation(MathObject term) {
         this.term = term;
     }
+
+	public Negation(String term) {
+		this.term = new Variable(term);
+	}
 
     public Negation() {
     }

--- a/src/main/java/com/discretion/statement/NotElementOf.java
+++ b/src/main/java/com/discretion/statement/NotElementOf.java
@@ -1,0 +1,24 @@
+package com.discretion.statement;
+
+import com.discretion.MathObject;
+
+public class NotElementOf extends ElementOf {
+
+	@Override
+	public boolean isNegative() {
+		return true;
+	}
+
+	@Override
+	public MathObject negate() {
+		return new ElementOf(element, set);
+	}
+
+	public NotElementOf(MathObject element, MathObject set) {
+		super(element, set);
+	}
+
+	public NotElementOf(String element, String set) {
+		super(element, set);
+	}
+}

--- a/src/main/java/com/discretion/statement/Statement.java
+++ b/src/main/java/com/discretion/statement/Statement.java
@@ -7,5 +7,5 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         use = JsonTypeInfo.Id.MINIMAL_CLASS,
         include = JsonTypeInfo.As.PROPERTY,
         property = "type")
-public interface Statement extends MathObject {
+public abstract class Statement extends MathObject {
 }

--- a/src/main/java/com/discretion/statement/SubsetOf.java
+++ b/src/main/java/com/discretion/statement/SubsetOf.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class SubsetOf implements Statement {
+public class SubsetOf extends Statement {
 
     public boolean equals(Object other) {
         if (!(other instanceof SubsetOf))

--- a/src/main/java/com/discretion/statement/Variable.java
+++ b/src/main/java/com/discretion/statement/Variable.java
@@ -3,7 +3,7 @@ package com.discretion.statement;
 import com.discretion.MathObject;
 import com.discretion.MathObjectVisitor;
 
-public class Variable implements Statement {
+public class Variable extends Statement {
 
     public boolean equals(Object other) {
         return other instanceof Variable && ((Variable)other).name.equals(name);

--- a/src/test/java/com/discretion/solver/inference/DeMorgansTest.java
+++ b/src/test/java/com/discretion/solver/inference/DeMorgansTest.java
@@ -1,13 +1,9 @@
 package com.discretion.solver.inference;
 
-import com.discretion.statement.Variable;
+import com.discretion.statement.*;
 import com.discretion.proof.ProofStatement;
 import com.discretion.solver.environment.NestedTruthEnvironment;
 import com.discretion.solver.environment.TruthEnvironment;
-import com.discretion.statement.Conjunction;
-import com.discretion.statement.Disjunction;
-import com.discretion.statement.Negation;
-import com.discretion.statement.Statement;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,7 +44,37 @@ public class DeMorgansTest {
 		Statement expected = new Negation(new Disjunction(new Negation(new Variable("p")), new Negation(new Variable("q"))));
 		assertThat("(p and q) implies ~(~p or ~q)",
 				inferences.get(0).getStatement(),
-				equalToExpression(expected));
+				is(equalToExpression(expected)));
+	}
+
+	/**
+	 * Tests that terms are negated in the appropriate manner
+	 * - for example an ElementOf is negated into a NotElementOf
+	 *
+	 * Given:
+	 *      x ∈ A ∧ x ∉ B
+	 *
+	 * Infer:
+	 *     ¬(x ∉ A ∨ x ∈ B)
+	 */
+	@Test
+	public void testSpecialNegation() {
+		TruthEnvironment environment = new NestedTruthEnvironment(
+				new Conjunction(
+						new ElementOf("x", "A"),
+						new NotElementOf("x", "B")));
+		List<ProofStatement> inferences = deMorgan.getInferences(environment);
+
+		assertThat("Only one inference should be made", inferences.size(), is(1));
+
+		Statement expected = new Negation(
+				new Disjunction(
+						new NotElementOf("x", "A"),
+						new ElementOf("x", "B")));
+
+		assertThat("ElementOf should be negated as NotElementOf",
+				inferences.get(0).getStatement(),
+				is(equalToExpression(expected)));
 	}
 
 	/**
@@ -63,15 +89,15 @@ public class DeMorgansTest {
 	@Test
 	public void testInnerNegations() {
 		TruthEnvironment environment = new NestedTruthEnvironment(
-				new Conjunction(new Negation(new Variable("p")), new Negation(new Variable("q"))));
+				new Conjunction(new Negation("p"), new Negation("q")));
 		List<ProofStatement> inferences = deMorgan.getInferences(environment);
 
 		assertThat("Only one inference should be made", inferences.size(), is(1));
 
-		Statement expected = new Negation(new Disjunction(new Variable("p"), new Variable("q")));
+		Statement expected = new Negation(new Disjunction("p", "q"));
 		assertThat("(~p and ~q) implies ~(p or q)",
 				inferences.get(0).getStatement(),
-				equalToExpression(expected));
+				is(equalToExpression(expected)));
 	}
 
 	/**
@@ -86,15 +112,15 @@ public class DeMorgansTest {
 	@Test
 	public void testOuterNegation() {
 		TruthEnvironment environment = new NestedTruthEnvironment(
-				new Negation(new Conjunction(new Variable("p"), new Variable("q"))));
+				new Negation(new Conjunction("p", "q")));
 		List<ProofStatement> inferences = deMorgan.getInferences(environment);
 
 		assertThat("Only one inference should be made", inferences.size(), is(1));
 
-		Statement expected = new Disjunction(new Negation(new Variable("p")), new Negation(new Variable("q")));
+		Statement expected = new Disjunction(new Negation("p"), new Negation("q"));
 		assertThat("(~p and ~q) implies ~(p or q)",
 				inferences.get(0).getStatement(),
-				equalToExpression(expected));
+				is(equalToExpression(expected)));
 	}
 
 	private DeMorgansLaw deMorgan;

--- a/src/test/java/com/discretion/solver/inference/SetComplementTest.java
+++ b/src/test/java/com/discretion/solver/inference/SetComplementTest.java
@@ -1,5 +1,6 @@
 package com.discretion.solver.inference;
 
+import com.discretion.statement.NotElementOf;
 import com.discretion.statement.Variable;
 import com.discretion.expression.SetComplement;
 import com.discretion.proof.ProofStatement;
@@ -28,7 +29,7 @@ public class SetComplementTest {
 	 *      x ∈ X
 	 *
 	 * Infer:
-	 *      ¬(x ∈ ~X)
+	 *      x ∉ ~X
 	 */
 	@Test
 	public void testInSet() {
@@ -40,13 +41,13 @@ public class SetComplementTest {
 		assertThat("(x in X) implies (x not in ~X)",
 				inferences.get(0).getStatement(),
 				is(equalToExpression(
-						new Negation(new ElementOf(new Variable("x"), new SetComplement("X"))))
-				));
+						new NotElementOf(new Variable("x"), new SetComplement("X"))
+				)));
 	}
 
 	/**
 	 * Given:
-	 *      ¬(x ∈ X)
+	 *      x ∉ X
 	 *
 	 * Infer:
 	 *      x ∈ ~X
@@ -54,7 +55,7 @@ public class SetComplementTest {
 	@Test
 	public void testNotInSet() {
 		TruthEnvironment environment = new NestedTruthEnvironment(
-				new Negation(new ElementOf("x", "X")));
+				new NotElementOf("x", "X"));
 		List<ProofStatement> inferences = complement.getInferences(environment);
 
 		assertThat("Only one inference should be made", inferences.size(), is(1));
@@ -70,7 +71,7 @@ public class SetComplementTest {
 	 *      x ∈ ~X
 	 *
 	 * Infer:
-	 *      ¬(x ∈ X)
+	 *      x ∉ X
 	 */
 	@Test
 	public void testInComplement() {
@@ -81,14 +82,12 @@ public class SetComplementTest {
 		assertThat("Only one inference should be made", inferences.size(), is(1));
 		assertThat("(x in ~X) implies (x not in X)",
 				inferences.get(0).getStatement(),
-				is(equalToExpression(
-						new Negation(new ElementOf("x", "X")))
-				));
+				is(equalToExpression(new NotElementOf("x", "X"))));
 	}
 
 	/**
 	 * Given:
-	 *      ¬(x ∈ ~X)
+	 *      x ∉ ~X
 	 *
 	 * Infer:
 	 *      x ∈ X
@@ -96,7 +95,7 @@ public class SetComplementTest {
 	@Test
 	public void testNotInComplement() {
 		TruthEnvironment environment = new NestedTruthEnvironment(
-				new Negation(new ElementOf(new Variable("x"), new SetComplement("X"))));
+				new NotElementOf(new Variable("x"), new SetComplement("X")));
 		List<ProofStatement> inferences = complement.getInferences(environment);
 
 		assertThat("Only one inference should be made", inferences.size(), is(1));

--- a/src/test/java/com/discretion/solver/inference/SetDifferenceTest.java
+++ b/src/test/java/com/discretion/solver/inference/SetDifferenceTest.java
@@ -1,0 +1,53 @@
+package com.discretion.solver.inference;
+
+import com.discretion.expression.SetComplement;
+import com.discretion.expression.SetDifference;
+import com.discretion.proof.ProofStatement;
+import com.discretion.solver.environment.NestedTruthEnvironment;
+import com.discretion.solver.environment.TruthEnvironment;
+import com.discretion.statement.Conjunction;
+import com.discretion.statement.ElementOf;
+import com.discretion.statement.NotElementOf;
+import com.discretion.statement.Variable;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.discretion.EqualExpression.equalToExpression;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class SetDifferenceTest {
+
+	@Before
+	public void setUpTest() {
+		difference = new SetDifferenceInference();
+	}
+
+	/**
+	 * Given:
+	 *      x ∈ A - B
+	 *
+	 * Infer:
+	 *      x ∈ A ∧ x ∉ B
+	 */
+	@Test
+	public void testInDifference() {
+		TruthEnvironment environment = new NestedTruthEnvironment(
+				new ElementOf(new Variable("x"), new SetDifference("A", "B")));
+		List<ProofStatement> inferences = difference.getInferences(environment);
+
+		assertThat("Only one inference should be made", inferences.size(), is(1));
+		assertThat("(x not in ~X) implies (x in X)",
+				inferences.get(0).getStatement(),
+				is(equalToExpression(
+						new Conjunction(
+								new ElementOf("x", "A"),
+								new NotElementOf("x", "B")
+						)
+				)));
+	}
+
+	private SetDifferenceInference difference;
+}


### PR DESCRIPTION
Added NotElementOf as a replacement to Negation(ElementOf)). Any rule that would negate term relies on the MathObject.negate() to produce the negated term. Rules that rely on negations must also check for a NotElementOf.